### PR TITLE
git branch: main is updated in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     stages {
         stage("Checkout code") {  
             steps {
-                git changelog: false, poll: false, url: 'https://github.com/abhishek-balaji-2025/company-project-java-codebase.git'
+                git branch: 'main', changelog: false, poll: false, url: 'https://github.com/abhishek-balaji-2025/company-project-java-codebase.git'
             }
         }
 


### PR DESCRIPTION
"git branch: 'main', changelog: false, poll: false, url: 'https://github.com/abhishek-balaji-2025/company-project-java-codebase.git'"

This tells Jenkins to checkout the main branch explicitly and avoids looking for master.