### PR TITLE
Illegal characters were removed from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.company.project</groupId>
     <artifactId>company-project-java-codebase</artifactId>
     <version>1.0.0</version>
-    <packaging>war</packaging> <!-- 👈 WAR packaging -->
+    <packaging>war</packaging> <!-- WAR packaging -->
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -25,7 +25,7 @@
     </dependencies>
 
     <build>
-        <finalName>sampleapp</finalName> <!-- 👈 Output file: sampleapp.war -->
+        <finalName>sampleapp</finalName> <!-- Output file: sampleapp.war -->
         <plugins>
             <!-- Java Compiler -->
             <plugin>


### PR DESCRIPTION
Just replace your existing pom.xml content with this, commit, and push. Your Maven build should no longer choke on illegal characters.